### PR TITLE
Use destructuring for PicoLLM class import

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,11 +276,13 @@ yarn add @picovoice/picollm-node
 Create instances of the picoLLM class:
 
 ```javascript
-const PicoLLM = require("@picovoice/picollm-node");
+const { PicoLLM } = require("@picovoice/picollm-node");
 const pllm = new PicoLLM('${ACCESS_KEY}', '${MODEL_PATH}');
 
 const res = pllm.generate('${PROMPT}');
 console.log(res.completion);
+
+pllm.release();
 ```
 
 Replace `${ACCESS_KEY}` with yours obtained from Picovoice Console, `${MODEL_PATH}` to the path to a model file


### PR DESCRIPTION
- Update require statement to import the class instead of the package to avoid error that occurs when running as original described in docs 
- Add an explicit call to the release method to improve clarity of the example 