### PR TITLE
Fix the Interrupt() test

### DIFF
--- a/binding/dotnet/PicoLLMTest/MainTest.cs
+++ b/binding/dotnet/PicoLLMTest/MainTest.cs
@@ -344,8 +344,7 @@ namespace PicoLLMTest
 
             using (PicoLLM picoLLM = PicoLLM.Create(_accessKey, _modelPath, _device))
             {
-                Task<PicoLLMCompletion> generateTask = Task.Run(() => picoLLM.Generate(prompt));
-                picoLLM.Interrupt();
+                Task<PicoLLMCompletion> generateTask = Task.Run(() => picoLLM.Generate(prompt, streamCallback: (_) => picoLLM.Interrupt()));
                 PicoLLMCompletion res = generateTask.Result;
                 Assert.AreEqual(res.Endpoint, PicoLLMEndpoint.INTERRUPTED);
             }


### PR DESCRIPTION
Previously the `TestInterrupt()` test has a probability to fail, that is because
1. The interruption takes place before the generation task begins.
2. The interruption happens after the generation is over.

This PR fixes this problem by calling the `Interrupt()` function in the streaming callback to ensure generation is in process when `Interrupt()` is called.